### PR TITLE
fixup gemspec

### DIFF
--- a/foreman_dhcp_browser.gemspec
+++ b/foreman_dhcp_browser.gemspec
@@ -8,10 +8,10 @@ Gem::Specification.new do |s|
   s.name        = "foreman_dhcp_browser"
   s.version     = ForemanDhcpBrowser::VERSION
   s.authors     = ["Ohad Levy"]
-  s.email       = ["ohadlevy@gmail.com"]
-  s.homepage    = "TODO"
-  s.summary     = "TODO: Summary of ForemanDhcpBrowser."
-  s.description = "TODO: Description of ForemanDhcpBrowser."
+  s.email       = %q{ohadlevy@gmail.com}
+  s.homepage    = %q{https://github.com/theforeman/foreman_dhcp_browser}
+  s.summary     = %q{DHCP browser plugin for Foreman}
+  s.description = %q{Plugin for Foreman to browse and add/edit/delete DHCP leases independent of Foreman's host creation}
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]


### PR DESCRIPTION
I keep getting

```
Using foreman_dhcp_browser (0.0.1) from https://github.com/theforeman/foreman_dhcp_browser.git (at master)
foreman_dhcp_browser at /usr/share/foreman/vendor/ruby/1.9.1/bundler/gems/foreman_dhcp_browser-f5e0c5c6110d did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  "FIXME" or "TODO" is not a description
```
