### PR TITLE
adding permissions to use the dhcp browser for non-administrators

### DIFF
--- a/lib/foreman_dhcp_browser/engine.rb
+++ b/lib/foreman_dhcp_browser/engine.rb
@@ -3,6 +3,21 @@ module ForemanDhcpBrowser
   class Engine < ::Rails::Engine
     initializer 'foreman_dhcp_browser.register_plugin', before: :finisher_hook do |_app|
       Foreman::Plugin.register :foreman_dhcp_browser do
+        security_block :foreman_dhcp_browser do
+          permission :view_dhcp, {
+            :dhcp => [:index, :show, :find_proxy, :find_record]
+          }
+          permission :new_dhcp, {
+            :dhcp => [:new, :create]
+          }
+          permission :edit_dhcp, {
+            :dhcp => [:edit, :update]
+          }
+          permission :delete_dhcp, {
+            :dhcp => [:destroy]
+          }
+        end
+        add_all_permissions_to_default_roles
       end
     end
 


### PR DESCRIPTION
This change adds permission filters for the Foreman DHCP browser, allowing non-administrators to be given create/edit/delete/view permissions for DHCP leases. [#18]