### PR TITLE
Bring back compatibility with Foreman 3.13

### DIFF
--- a/lib/foreman_dhcp_browser/engine.rb
+++ b/lib/foreman_dhcp_browser/engine.rb
@@ -6,7 +6,7 @@ module ForemanDHCPBrowser
     initializer 'foreman_dhcp_browser.register_plugin', before: :finisher_hook do |app|
       app.reloader.to_prepare do
         Foreman::Plugin.register :foreman_dhcp_browser do
-          requires_foreman '>= 3.14.0'
+          requires_foreman '>= 3.13.0'
         end
       end
     end


### PR DESCRIPTION
Includes https://github.com/theforeman/foreman_dhcp_browser/pull/28. I'm not sure that works though because the spec file says `>= 3.14` now.